### PR TITLE
Fix byte encoding appearing in NTLM Header

### DIFF
--- a/python30/ntlm/HTTPNtlmAuthHandler.py
+++ b/python30/ntlm/HTTPNtlmAuthHandler.py
@@ -50,7 +50,9 @@ class AbstractNtlmAuthHandler:
             # ntlm secures a socket, so we must use the same socket for the complete handshake
             headers = dict(req.headers)
             headers.update(req.unredirected_hdrs)
-            auth = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(user, type1_flags)
+            auth = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(
+                user, type1_flags
+            ).decode('ascii')
             if req.headers.get(self.auth_header, None) == auth:
                 return None
             headers[self.auth_header] = auth
@@ -86,7 +88,9 @@ class AbstractNtlmAuthHandler:
                 auth_header_value, = m.groups()
 
             (ServerChallenge, NegotiateFlags) = ntlm.parse_NTLM_CHALLENGE_MESSAGE(auth_header_value[5:])
-            auth = 'NTLM %s' % ntlm.create_NTLM_AUTHENTICATE_MESSAGE(ServerChallenge, UserName, DomainName, pw, NegotiateFlags)
+            auth = 'NTLM %s' % ntlm.create_NTLM_AUTHENTICATE_MESSAGE(
+                ServerChallenge, UserName, DomainName, pw, NegotiateFlags
+            ).decode('ascii')
             headers[self.auth_header] = auth
             headers["Connection"] = "Close"
             headers = dict((name.title(), val) for name, val in list(headers.items()))


### PR DESCRIPTION
The ntml.create_ calls return a byte string and so when performing a string
substitution appear as "NTLM b'..HEX..'" rather than "NTML ..HEX.." use
decode('ascii') to convert to unicode before string substitution occurs.