### PR TITLE
Python >= 3.9 - Replaced deprecated function

### DIFF
--- a/python30/ntlm/ntlm.py
+++ b/python30/ntlm/ntlm.py
@@ -220,7 +220,7 @@ def create_NTLM_NEGOTIATE_MESSAGE(user, type1_flags=NTLM_TYPE1_FLAGS):
     
 def parse_NTLM_CHALLENGE_MESSAGE(msg2):
     ""
-    msg2 = base64.decodestring(bytes(msg2, 'ascii'))
+    msg2 = base64.decodebytes(bytes(msg2, 'ascii'))
     Signature = msg2[0:8]
     msg_type = struct.unpack("<I",msg2[8:12])[0]
     assert(msg_type==2)


### PR DESCRIPTION
Since python 3.1 `base64.decodestring` is a deprecated alias of `base64.decodebytes(s)`. In python 3.9, the function is no longer available and must be replaced.

Official documentation: 
- https://docs.python.org/3.8/library/base64.html#base64.decodestring
- https://docs.python.org/3.9/library/base64.html